### PR TITLE
Unique indexes for NeftyQuest leaderboard materialized view

### DIFF
--- a/definitions/materialized/neftyquest_leaderboard_template.sql
+++ b/definitions/materialized/neftyquest_leaderboard_template.sql
@@ -70,7 +70,7 @@ FROM (
     JOIN atomicmarket_tokens AS tokens ON tokens.token_symbol = leaderboard.symbol
 WHERE (total_sold + total_bought) > {{min_volume}};
 
-CREATE UNIQUE INDEX nefy_quest_leaderboard_pkey ON nefy_quest_leaderboard_{{quest_id}} (account);
+CREATE UNIQUE INDEX nefy_quest_leaderboard_pkey_{{quest_id}} ON nefy_quest_leaderboard_{{quest_id}} (account);
 
-CREATE INDEX nefy_quest_leaderboard_account ON nefy_quest_leaderboard_{{quest_id}} USING btree (account);
-CREATE INDEX nefy_quest_leaderboard_experience ON nefy_quest_leaderboard_{{quest_id}} USING btree (experience);
+CREATE INDEX nefy_quest_leaderboard_account_{{quest_id}} ON nefy_quest_leaderboard_{{quest_id}} USING btree (account);
+CREATE INDEX nefy_quest_leaderboard_experience_{{quest_id}} ON nefy_quest_leaderboard_{{quest_id}} USING btree (experience);


### PR DESCRIPTION
Create indexes with a unique name, postgres does not allow same names even if they're on a different table